### PR TITLE
Semgrep Finding: python.django.security.django-no-csrf-token.django-no-csrf-token

### DIFF
--- a/bad/templates/mfa.enable.html
+++ b/bad/templates/mfa.enable.html
@@ -6,12 +6,14 @@
     <img alt="Embedded Image" src="data:image/png;base64,{{ img_str }}" />
 
     <form method="POST" class="w3-padding-32">
-      <div class="w3-section">
-        <label><b>OTP</b></label>
-        <input class="w3-input w3-border" type="text" name="otp" required>
-        <button class="w3-button w3-block w3-black w3-section w3-padding" type="submit">Enable</button>
-      </div>
-    </form>
+  <div class="w3-section">
+    <label><b>OTP</b></label>
+    <input class="w3-input w3-border" type="text" name="otp" required autocomplete="off">
+    <button class="w3-button w3-block w3-black w3-section w3-padding" type="submit">Enable</button>
+  </div>
+</form>
+```
+
 
     {{ secret_url }}
 


### PR DESCRIPTION
[Harness Pipeline](https://app.harness.io/ng/account/vpCkHKsDSxK9_KYfjCTMKA/module/sto/orgs/SSCA/projects/Exploratory/pipelines/vulpyvpc/executions/MLUl0ygCR6uOSTLGs_7iFg/security?storeType=INLINE&issue=06hYDLrug7HP58jAeH4pp0+tejakummarikuntla%2Fvulpy%3Amaster)

**Vulnerability:** Cross-Site Request Forgery (CSRF) occurs when a malicious website, email, blog, instant message, or program causes a user's web browser to perform an unwanted action on a trusted site when the user is authenticated.  The vulnerability arises from missing CSRF tokens in manually created Django forms.

**Remediation Concepts:** Django's CSRF protection mechanism uses tokens to verify that requests originate from the user's own browser, not a malicious site.  The `{% csrf_token %}` template tag inserts this crucial token into forms.

**Remediation Steps:**

1. **Locate the vulnerable form:** Identify the Django template file containing the manually created form lacking a CSRF token.

2. **Insert the CSRF token:** Add the `{% csrf_token %}` template tag *inside* the `<form>` tag of your manually created form.  It should be placed before any other form elements.  For example:

   ```html+django
   <form method="post" action="{% url 'my_view' %}">
       {% csrf_token %}
       <!-- Rest of your form fields -->
       <button type="submit">Submit</button>
   </form>
   ```

3. **Test the fix:**  Thoroughly test the application to ensure the form now correctly submits with the CSRF token and prevents CSRF attacks.


>**Code suggestions may produce inaccurate results or introduce new vulnerabilities. Review the output carefully before use.**